### PR TITLE
Create Page for RecommendationRequest and adjustments to navigation endpoints

### DIFF
--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -3,6 +3,10 @@ import HomePage from "main/pages/HomePage";
 import ProfilePage from "main/pages/ProfilePage";
 import AdminUsersPage from "main/pages/AdminUsersPage";
 
+import RecommendationRequestIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import RecommendationRequestEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+
 import UCSBDatesIndexPage from "main/pages/UCSBDates/UCSBDatesIndexPage";
 import UCSBDatesCreatePage from "main/pages/UCSBDates/UCSBDatesCreatePage";
 import UCSBDatesEditPage from "main/pages/UCSBDates/UCSBDatesEditPage";
@@ -76,6 +80,22 @@ function App() {
             </>
           )
         }
+        {
+          hasRole(currentUser, "ROLE_USER") && (
+            <>
+              <Route exact path="/recommendationrequest" element={<RecommendationRequestIndexPage />} />
+            </>
+          )
+        }
+        {
+          hasRole(currentUser, "ROLE_ADMIN") && (
+            <>
+              <Route exact path="/recommendationrequest/edit/:id" element={<RecommendationRequestEditPage />} />
+              <Route exact path="/recommendationrequest/create" element={<RecommendationRequestCreatePage />} />
+            </>
+          )
+        }
+        
       </Routes>
     </BrowserRouter>
   );

--- a/frontend/src/main/components/Nav/AppNavbar.js
+++ b/frontend/src/main/components/Nav/AppNavbar.js
@@ -57,6 +57,7 @@ export default function AppNavbar({ currentUser, systemInfo, doLogout, currentUr
                   <Nav.Link as={Link} to="/restaurants">Restaurants</Nav.Link>
                   <Nav.Link as={Link} to="/ucsbdates">UCSB Dates</Nav.Link>
                   <Nav.Link as={Link} to="/placeholder">Placeholder</Nav.Link>
+                  <Nav.Link as={Link} to="/recommendationrequest">RecommendationRequest</Nav.Link>
                 </>
               )
             }

--- a/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
+++ b/frontend/src/main/components/RecommendationRequest/RecommendationRequestTable.js
@@ -11,7 +11,7 @@ export default function RecommendationRequestTable({ requests, currentUser }) {
     const navigate = useNavigate();
 
     const editCallback = (cell) => {
-        navigate(`/RecommendationRequest/edit/${cell.row.values.id}`)
+        navigate(`/recommendationrequest/edit/${cell.row.values.id}`)
     }
 
     // Stryker disable all : hard to test for query caching

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestCreatePage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Create page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestCreatePage.js
@@ -1,12 +1,52 @@
 import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+import RecForm from "main/components/RecommendationRequest/RecommendationRequestForm";
+import { Navigate } from 'react-router-dom'
+import { useBackendMutation } from "main/utils/useBackend";
+import { toast } from "react-toastify";
 
-export default function RecommendationRequestCreatePage() {
+export default function RecommendationRequestCreatePage({storybook=false}) {
 
-  // Stryker disable all : placeholder for future implementation
+  const objectToAxiosParams = (request) => ({
+    url: "/api/RecommendationRequest/post",
+    method: "POST",
+    params: {
+      requesterEmail: request.requesterEmail,
+      professorEmail: request.professorEmail,
+      explanation: request.explanation,
+      dateRequested: request.dateRequested,
+      dateNeeded: request.dateNeeded,
+      done: request.done
+    }
+  });
+
+  const onSuccess = (request) => {
+    toast(`New recommendation request created - id: ${request.id}`);
+  }
+
+  const mutation = useBackendMutation(
+    objectToAxiosParams,
+     { onSuccess }, 
+     // Stryker disable next-line all : hard to set up test for caching
+     ["/api/RecommendationRequest/all"]
+     );
+
+  const { isSuccess } = mutation
+
+  const onSubmit = async (data) => {
+    mutation.mutate(data);
+  }
+
+  if (isSuccess && !storybook) {
+    return <Navigate to="/recommendationrequest" />
+  }
+
   return (
     <BasicLayout>
       <div className="pt-2">
-        <h1>Create page not yet implemented</h1>
+        <h1>Create New Recommendation Request</h1>
+
+        <RecForm submitAction={onSubmit} />
+
       </div>
     </BasicLayout>
   )

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestEditPage.js
@@ -1,0 +1,13 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestEditPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Edit page not yet implemented</h1>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -1,0 +1,15 @@
+import BasicLayout from "main/layouts/BasicLayout/BasicLayout";
+
+export default function RecommendationRequestIndexPage() {
+
+  // Stryker disable all : placeholder for future implementation
+  return (
+    <BasicLayout>
+      <div className="pt-2">
+        <h1>Index page not yet implemented</h1>
+        <p><a href="/placeholder/create">Create</a></p>
+        <p><a href="/placeholder/edit/1">Edit</a></p>
+      </div>
+    </BasicLayout>
+  )
+}

--- a/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
+++ b/frontend/src/main/pages/RecommendationRequest/RecommendationRequestIndexPage.js
@@ -7,8 +7,8 @@ export default function RecommendationRequestIndexPage() {
     <BasicLayout>
       <div className="pt-2">
         <h1>Index page not yet implemented</h1>
-        <p><a href="/placeholder/create">Create</a></p>
-        <p><a href="/placeholder/edit/1">Edit</a></p>
+        <p><a href="/recommendationrequest/create">Create</a></p>
+        <p><a href="/recommendationrequest/edit/1">Edit</a></p>
       </div>
     </BasicLayout>
   )

--- a/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.js
+++ b/frontend/src/stories/pages/RecommendationRequest/RecommendationRequestCreatePage.stories.js
@@ -1,0 +1,29 @@
+import React from 'react';
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import { rest } from "msw";
+
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+
+export default {
+    title: 'pages/RecommendationRequest/RecommendationRequestCreatePage',
+    component: RecommendationRequestCreatePage
+};
+
+const Template = () => <RecommendationRequestCreatePage storybook={true} />;
+
+export const Default = Template.bind({});
+Default.parameters = {
+    msw: [
+        rest.get('/api/currentUser', (_req, res, ctx) => {
+            return res(ctx.json(apiCurrentUserFixtures.userOnly));
+        }),
+        rest.get('/api/systemInfo', (_req, res, ctx) => {
+            return res(ctx.json(systemInfoFixtures.showingNeither));
+        }),
+        rest.post('/api/RecommendationRequest/post', (req, res, ctx) => {
+            window.alert("POST: " + JSON.stringify(req.url));
+            return res(ctx.status(200),ctx.json({}));
+        }),
+    ]
+}

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestForm.test.js
@@ -113,7 +113,7 @@ describe("RecommendationRequestForm tests", () => {
         fireEvent.change(explanationField, { target: { value: 'For grad school' } });
         fireEvent.change(dateRequestedField, { target: { value: '2022-03-05T10:00' } });
         fireEvent.change(dateNeededField, { target: { value: '2023-07-11T12:00' } });
-        fireEvent.change(doneField, { target: { value: true } });
+        fireEvent.click(doneField);
         fireEvent.click(submitButton);
 
         await waitFor(() => expect(mockSubmitAction).toHaveBeenCalled());

--- a/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
+++ b/frontend/src/tests/components/RecommendationRequest/RecommendationRequestTable.test.js
@@ -116,7 +116,7 @@ describe("UserTable tests", () => {
     
     fireEvent.click(editButton);
 
-    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/RecommendationRequest/edit/1'));
+    await waitFor(() => expect(mockedNavigate).toHaveBeenCalledWith('/recommendationrequest/edit/1'));
 
   });
 

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -1,0 +1,41 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+describe("PlaceholderCreatePage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+       
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+    });
+
+});

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestCreatePage.test.js
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import PlaceholderCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
+import { render, waitFor, fireEvent, screen } from "@testing-library/react";
+import RecommendationRequestCreatePage from "main/pages/RecommendationRequest/RecommendationRequestCreatePage";
 import { QueryClient, QueryClientProvider } from "react-query";
 import { MemoryRouter } from "react-router-dom";
 
@@ -8,34 +8,111 @@ import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
 import axios from "axios";
 import AxiosMockAdapter from "axios-mock-adapter";
 
-describe("PlaceholderCreatePage tests", () => {
+const mockToast = jest.fn();
+jest.mock('react-toastify', () => {
+    const originalModule = jest.requireActual('react-toastify');
+    return {
+        __esModule: true,
+        ...originalModule,
+        toast: (x) => mockToast(x)
+    };
+});
 
-    const axiosMock = new AxiosMockAdapter(axios);
+const mockNavigate = jest.fn();
+jest.mock('react-router-dom', () => {
+    const originalModule = jest.requireActual('react-router-dom');
+    return {
+        __esModule: true,
+        ...originalModule,
+        Navigate: (x) => { mockNavigate(x); return null; }
+    };
+});
 
-    const setupUserOnly = () => {
+describe("RecommendationRequestCreatePage tests", () => {
+
+    const axiosMock =new AxiosMockAdapter(axios);
+
+    beforeEach(() => {
         axiosMock.reset();
         axiosMock.resetHistory();
         axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
         axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
-    };
+    });
 
-    const queryClient = new QueryClient();
-    test("Renders expected content", () => {
-        // arrange
-
-        setupUserOnly();
-       
-        // act
+    test("renders without crashing", () => {
+        const queryClient = new QueryClient();
         render(
             <QueryClientProvider client={queryClient}>
                 <MemoryRouter>
-                    <PlaceholderCreatePage />
+                    <RecommendationRequestCreatePage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+    });
+
+    test("when you fill in the form and hit submit, it makes a request to the backend", async () => {
+
+        const queryClient = new QueryClient();
+        const request = {
+            id: 1,
+            requesterEmail: "apchau@ucsb.edu",
+            professorEmail: "pconrad@ucsb.edu",
+            explanation: "Request explanation goes here",
+            dateRequested: "2022-03-08T12:00",
+            dateNeeded: "2023-01-05T12:00",
+            done: true
+        };
+
+        axiosMock.onPost("/api/RecommendationRequest/post").reply( 202, request );
+
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <RecommendationRequestCreatePage />
                 </MemoryRouter>
             </QueryClientProvider>
         );
 
-        // assert
-        expect(screen.getByText("Create page not yet implemented")).toBeInTheDocument();
+        await waitFor(() => {
+            expect(screen.getByTestId("RecommendationRequestForm-requesterEmail")).toBeInTheDocument();
+        });
+
+        const requesterEmailField = screen.getByTestId("RecommendationRequestForm-requesterEmail");
+        const professorEmailField = screen.getByTestId("RecommendationRequestForm-professorEmail");
+        const explanationField = screen.getByTestId("RecommendationRequestForm-explanation");
+        const dateRequestedField = screen.getByTestId("RecommendationRequestForm-dateRequested");
+        const dateNeededField = screen.getByTestId("RecommendationRequestForm-dateNeeded");
+        const doneField = screen.getByTestId("RecommendationRequestForm-done");
+        const submitButton = screen.getByTestId("RecommendationRequestForm-submit");
+
+        fireEvent.change(requesterEmailField, { target: { value: 'apchau@ucsb.edu' } });
+        fireEvent.change(professorEmailField, { target: { value: 'pconrad@ucsb.edu' } });
+        fireEvent.change(explanationField, { target: { value: 'Request explanation goes here' } });
+        fireEvent.change(dateRequestedField, { target: { value: '2022-03-08T12:00:00' } });
+        fireEvent.change(dateNeededField, { target: { value: '2023-01-05T12:00:00' } });
+        fireEvent.click(doneField);
+
+        expect(submitButton).toBeInTheDocument();
+
+        fireEvent.click(submitButton);
+
+        await waitFor(() => expect(axiosMock.history.post.length).toBe(1));
+
+        expect(axiosMock.history.post[0].params).toEqual(
+            {
+                "requesterEmail": "apchau@ucsb.edu",
+                "professorEmail": "pconrad@ucsb.edu",
+                "explanation": "Request explanation goes here",
+                "dateRequested": "2022-03-08T12:00",
+                "dateNeeded": "2023-01-05T12:00",
+                "done": true
+        });
+
+        expect(mockToast).toBeCalledWith("New recommendation request created - id: 1");
+        expect(mockNavigate).toBeCalledWith({ "to": "/recommendationrequest" });
     });
 
+
 });
+
+

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestEditPage.test.js
@@ -1,0 +1,44 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderEditPage from "main/pages/RecommendationRequest/RecommendationRequestEditPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("PlaceholderEditPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderEditPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Edit page not yet implemented")).toBeInTheDocument();
+    });
+
+});
+
+

--- a/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
+++ b/frontend/src/tests/pages/RecommendationRequest/RecommendationRequestIndexPage.test.js
@@ -1,0 +1,46 @@
+import { render, screen } from "@testing-library/react";
+import PlaceholderIndexPage from "main/pages/RecommendationRequest/RecommendationRequestIndexPage";
+import { QueryClient, QueryClientProvider } from "react-query";
+import { MemoryRouter } from "react-router-dom";
+
+import { apiCurrentUserFixtures } from "fixtures/currentUserFixtures";
+import { systemInfoFixtures } from "fixtures/systemInfoFixtures";
+import axios from "axios";
+import AxiosMockAdapter from "axios-mock-adapter";
+
+
+describe("PlaceholderIndexPage tests", () => {
+
+    const axiosMock = new AxiosMockAdapter(axios);
+
+    const setupUserOnly = () => {
+        axiosMock.reset();
+        axiosMock.resetHistory();
+        axiosMock.onGet("/api/currentUser").reply(200, apiCurrentUserFixtures.userOnly);
+        axiosMock.onGet("/api/systemInfo").reply(200, systemInfoFixtures.showingNeither);
+    };
+
+    const queryClient = new QueryClient();
+    test("Renders expected content", () => {
+        // arrange
+
+        setupUserOnly();
+
+        // act
+        render(
+            <QueryClientProvider client={queryClient}>
+                <MemoryRouter>
+                    <PlaceholderIndexPage />
+                </MemoryRouter>
+            </QueryClientProvider>
+        );
+
+        // assert
+        expect(screen.getByText("Index page not yet implemented")).toBeInTheDocument();
+        expect(screen.getByText("Create")).toBeInTheDocument();
+        expect(screen.getByText("Edit")).toBeInTheDocument();
+    });
+
+});
+
+


### PR DESCRIPTION
Created and passed test coverage for Create page of Recommendation Request database table. Also adjusted RecommendationRequestTable and RecommendationRequestIndexPage to use /recommendationrequest as navigation endpoint.
<img width="1423" alt="Screen Shot 2023-11-05 at 11 04 55 PM" src="https://github.com/ucsb-cs156-f23/team03-f23-6pm-1/assets/91815430/12ba4edb-50fe-4151-a2b7-78908f89c391">

Link to Storybook PR:
https://ucsb-cs156-f23.github.io/team03-f23-6pm-1/prs/73/storybook/?path=/story/pages-recommendationrequest-recommendationrequestcreatepage--default

Closes #31 